### PR TITLE
Fix endpoint URL in uploader

### DIFF
--- a/PD-detection-react/src/components/UploadImage.js
+++ b/PD-detection-react/src/components/UploadImage.js
@@ -52,7 +52,7 @@ class UploadImage extends Component {
         formData.append("myfile",this.state.imageFile)
         axios
         .post(
-            "http://127.0.0.1:8000/brainTumourDetection/getImage/",
+            "http://127.0.0.1:8000/PDDetection/getImage/",
             formData,
             {
                 headers:{


### PR DESCRIPTION
## Summary
- fix wrong endpoint URL in React uploader component

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f5d27348330b98e2cf473d16795